### PR TITLE
Fixed a bug which causes the script to fail where it should succeed

### DIFF
--- a/rbme
+++ b/rbme
@@ -407,7 +407,7 @@ if ! test -d "$BACKUP_PATH" ; then
 	die "ERROR: Backup path '$BACKUP_PATH' is not a directory !"
 fi
 
-if ! is_on_root_fs "$BACKUP_PATH" ; then
+if is_on_root_fs "$BACKUP_PATH" ; then
 	die "ERROR: Backup path '$BACKUP_PATH' is on /, must be on a different file-system !"
 fi
 


### PR DESCRIPTION
First of all thanks for making this script. I've been using it for years now and it has served me well.

I just happened to do some new things with it (pack it in a container) and ran accross a bug I think was introduced recently. See patch.

is_on_root_fs is true when target is on root fs, and in that case the process should die. The ! was here not in place.
